### PR TITLE
Fix disabled day bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nav-datovelger",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Enkel datovelger",
 	"main": "dist/datovelger/index.js",
 	"types": "dist/datovelger/index.d.ts",

--- a/src/datovelger/index.tsx
+++ b/src/datovelger/index.tsx
@@ -50,6 +50,8 @@ export interface Props {
 	locale?: 'nb';
 	/** Hvor kalender skal vises. Default under */
 	kalenderplassering?: KalenderPlassering;
+	/** Default false. Tillater bruker å velge ugyldig dato. */
+	kanVelgeUgyldigDato?: boolean;
 	/** dayPickerProps */
 	dayPickerProps?: DayPickerProps;
 }
@@ -243,6 +245,7 @@ class Datovelger extends React.Component<Props, State> {
 								}
 								onVelgDag={(d) => this.onVelgDag(d, true)}
 								onLukk={() => this.lukkKalender(true)}
+								kanVelgeUgyldigDato={this.props.kanVelgeUgyldigDato}
 								dayPickerProps={this.props.dayPickerProps}
 							/>
 						</KalenderPortal>

--- a/src/datovelger/kalender/Kalender.tsx
+++ b/src/datovelger/kalender/Kalender.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
-import DayPicker, { DayPickerProps, Modifier } from 'react-day-picker';
+import DayPicker, {
+	DayPickerProps,
+	Modifier,
+	DayModifiers
+} from 'react-day-picker';
 import * as moment from 'moment';
 import * as FocusTrap from 'focus-trap-react';
 import {
@@ -26,6 +30,7 @@ export interface Props {
 	onLukk: () => void;
 	utilgjengeligeDager?: Modifier[];
 	visUkenumre?: boolean;
+	kanVelgeUgyldigDato?: boolean;
 	dayPickerProps?: DayPickerProps;
 }
 
@@ -66,11 +71,11 @@ export class Kalender extends React.Component<Props, State> {
 		}
 	}
 
-	onByttDag(dato: Date, { disabled }: any) {
-	    if (!disabled) {
-	        this.props.onVelgDag(dato);
-        }
-    }
+	onByttDag(dato: Date, modifiers: DayModifiers) {
+		if (this.props.kanVelgeUgyldigDato || !modifiers.disabled) {
+			this.props.onVelgDag(dato);
+		}
+	}
 
 	onByttMåned(måned: Date) {
 		const fokusertDato = getFokusertDato(this.kalender);


### PR DESCRIPTION
The value of days picked from the DatePicker was propagated up regardless of
their disabled-state. This fix makes sure dates aren't actually passed on,
and that the Datepicker stays open, in the case that the user has picked
a date which is disabled.