### PR TITLE
feat(focus in calendar): add prop for initial focus in calendar

### DIFF
--- a/src/datepicker/Datepicker.tsx
+++ b/src/datepicker/Datepicker.tsx
@@ -31,6 +31,7 @@ export interface DatepickerProps {
     allowInvalidDateSelection?: boolean;
     showYearSelector?: boolean;
     dayPickerProps?: DayPickerProps;
+    setFocusOnDateWhenOpened?: boolean;
 }
 
 const Datepicker = ({
@@ -45,6 +46,7 @@ const Datepicker = ({
     showYearSelector,
     onChange,
     dayPickerProps,
+    setFocusOnDateWhenOpened,
 }: DatepickerProps) => {
     const [activeMonth, setActiveMonth] = useState<Date>(getDefaultMonth(value, limitations, dayPickerProps));
     const [calendarIsVisible, setCalendarIsVisible] = useState<boolean>(false);
@@ -103,6 +105,7 @@ const Datepicker = ({
                             allowInvalidDateSelection={allowInvalidDateSelection}
                             dayPickerProps={dayPickerProps}
                             showYearSelector={showYearSelector}
+                            setFocusOnDateWhenOpened={setFocusOnDateWhenOpened}
                         />
                     </CalendarPortal>
                 )}

--- a/src/datepicker/calendar/Calendar.tsx
+++ b/src/datepicker/calendar/Calendar.tsx
@@ -1,10 +1,10 @@
 import FocusTrap from 'focus-trap-react';
-import React, { MutableRefObject, useState } from 'react';
+import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
 import DayPicker, { DayModifiers, DayPickerProps, LocaleUtils, Modifier } from 'react-day-picker';
 import { DatepickerLocales, ISODateString } from '../types';
-import { setFocusOnCalendarMonth } from '../utils/calendarFocusUtils';
-import { dateToISODateString, ISODateStringToUTCDate } from '../utils/dateFormatUtils';
+import { setFocusOnCalendarMonth, setInitialDayFocus } from '../utils/calendarFocusUtils';
 import calendarLocaleUtils from '../utils/calendarLocaleUtils';
+import { dateToISODateString, ISODateStringToUTCDate } from '../utils/dateFormatUtils';
 import Navbar from './Navbar';
 
 require('dayjs/locale/nb.js');
@@ -24,6 +24,7 @@ interface Props {
     showYearSelector?: boolean;
     locale: DatepickerLocales;
     dayPickerProps?: DayPickerProps;
+    setFocusOnDateWhenOpened?: boolean;
 }
 
 export type NavigationFocusElement = 'nextMonth' | 'previousMonth' | 'year' | 'month';
@@ -43,6 +44,7 @@ const Calendar = React.forwardRef(function Calendar(props: Props, ref: React.Ref
         locale,
         onClose,
         onSelect,
+        setFocusOnDateWhenOpened,
         dayPickerProps,
     } = props;
 
@@ -93,28 +95,36 @@ const Calendar = React.forwardRef(function Calendar(props: Props, ref: React.Ref
         showWeekNumbers,
     };
 
+    const calendarRef = useRef<any>();
+    useEffect(() => {
+        if (setFocusOnDateWhenOpened && calendarRef.current) {
+            setInitialDayFocus(calendarRef.current);
+        }
+    }, [calendarRef, setFocusOnDateWhenOpened]);
     return (
         <div ref={ref} role="dialog" aria-label="Kalender" className="nav-datovelger__kalender">
-            <FocusTrap
-                active={true}
-                focusTrapOptions={{
-                    clickOutsideDeactivates: true,
-                    onDeactivate: onClose,
-                }}>
-                <DayPicker
-                    locale={locale}
-                    fromMonth={minDateString ? ISODateStringToUTCDate(minDateString) : undefined}
-                    toMonth={maxDateString ? ISODateStringToUTCDate(maxDateString) : undefined}
-                    canChangeMonth={false}
-                    selectedDays={dateString ? ISODateStringToUTCDate(dateString) : undefined}
-                    onDayClick={onSelectDate}
-                    onMonthChange={onChangeMonth}
-                    disabledDays={unavailableDates}
-                    {...dayPickerProps}
-                    {...dayPickerPropsToUse}
-                    month={displayMonth}
-                />
-            </FocusTrap>
+            <div ref={calendarRef}>
+                <FocusTrap
+                    active={true}
+                    focusTrapOptions={{
+                        clickOutsideDeactivates: true,
+                        onDeactivate: onClose,
+                    }}>
+                    <DayPicker
+                        locale={locale}
+                        fromMonth={minDateString ? ISODateStringToUTCDate(minDateString) : undefined}
+                        toMonth={maxDateString ? ISODateStringToUTCDate(maxDateString) : undefined}
+                        canChangeMonth={false}
+                        selectedDays={dateString ? ISODateStringToUTCDate(dateString) : undefined}
+                        onDayClick={onSelectDate}
+                        onMonthChange={onChangeMonth}
+                        disabledDays={unavailableDates}
+                        {...dayPickerProps}
+                        {...dayPickerPropsToUse}
+                        month={displayMonth}
+                    />
+                </FocusTrap>
+            </div>
         </div>
     );
 });

--- a/src/datepicker/styles/_dayPicker-overrides.less
+++ b/src/datepicker/styles/_dayPicker-overrides.less
@@ -70,9 +70,12 @@
                 color: @navRod !important;
                 font-style: italic;
             }
-            &--isPublicHoliday {
+            &--isPublicHoliday:not(.DayPicker-Day--selected) {
                 color: @navRod !important;
                 font-style: italic;
+            }
+            &--selected:last-child {
+                color: white !important;
             }
         }
         &-Weekday {

--- a/src/datepicker/utils/calendarFocusUtils.ts
+++ b/src/datepicker/utils/calendarFocusUtils.ts
@@ -1,13 +1,15 @@
 import { NavigationFocusElement } from '../calendar/Calendar';
-import { dayDateKey } from '.';
 
 type RefHTMLElement = HTMLElement | null;
 
-export const setFocusOnDate = (calendar: RefHTMLElement, date: Date) => {
+export const setInitialDayFocus = (calendar: RefHTMLElement) => {
     if (calendar) {
-        const el: HTMLElement = calendar.querySelector(`[data-date="${dayDateKey(date)}"]`) as HTMLElement;
+        const el: HTMLElement =
+            (calendar.querySelector(`.DayPicker-Day--selected`) as HTMLElement) ||
+            (calendar.querySelector(`.DayPicker-Day--today`) as HTMLElement) ||
+            (calendar.querySelector(`.DayPicker-Day[aria-disabled="false"]`) as HTMLElement);
         if (el) {
-            (el.parentNode as HTMLElement).focus();
+            el.focus();
         }
     }
 };

--- a/src/dev/examples/DatepickerExample.tsx
+++ b/src/dev/examples/DatepickerExample.tsx
@@ -30,8 +30,8 @@ const DatepickerExample: React.FunctionComponent = () => {
     const [locale, setLocale] = useState<DatepickerLocales>('nb');
 
     const takenRange: DatepickerDateRange = {
-        from: '2020-04-10',
-        to: '2022-04-11',
+        from: '2021-04-10',
+        to: '2021-04-11',
     };
 
     return (
@@ -48,6 +48,7 @@ const DatepickerExample: React.FunctionComponent = () => {
                         name: 'dateInput',
                         'aria-invalid': date !== '' && isISODateString(date) === false,
                     }}
+                    setFocusOnDateWhenOpened={true}
                     locale={locale}
                     calendarSettings={{ showWeekNumbers }}
                     showYearSelector={showYearSelector}


### PR DESCRIPTION
New prop added to DatePicker component.

`setFocusOnDateWhenOpened: true|false`

Defaults to false, which is current behaviour.

If set to true, this triggers the calendar to try to set focus on 
1. selectedDate
2. current date
3. first available date

If none of them are focusable, focus is as today, the first focusable element in the calendar.

#68